### PR TITLE
fix(Generator): Dynamically set ActiveRecord class

### DIFF
--- a/lib/generators/rails/observer_generator.rb
+++ b/lib/generators/rails/observer_generator.rb
@@ -18,7 +18,7 @@ module Rails
     private
 
     def active_record_klass
-      if Rails::VERSION::MAJOR > 4
+      if :Rails::VERSION::MAJOR > 4
         ApplicationRecord
       else
         ActiveRecord::Base

--- a/lib/generators/rails/observer_generator.rb
+++ b/lib/generators/rails/observer_generator.rb
@@ -9,9 +9,19 @@ module Rails
     end
 
     def include_observable_mixin
-      line = "class #{class_name} < ActiveRecord::Base"
+      line = "class #{class_name} < #{active_record_klass}"
       gsub_file "app/models/#{file_name.underscore}.rb", /(#{Regexp.escape(line)})/mi do |match|
         "#{match}\n  include PowerTypes::Observable"
+      end
+    end
+
+    private
+
+    def active_record_klass
+      if Rails::VERSION::MAJOR > 4
+        ApplicationRecord
+      else
+        ActiveRecord::Base
       end
     end
   end


### PR DESCRIPTION
Addresses #10.

Rails 5 models inherit from ApplicationRecord rather than ActiveRecord::Base as
in previous versions. This checks the Rails::VERSION::MAJOR and sets the class
accordingly in the generator.

Tested it manually, couldn't think of an obvious way to write spec coverage.
Happy to take direction and add some tests if you have ideas.