### PR TITLE
feat(observer): add support to before_commit and after_commit callbacks

### DIFF
--- a/lib/power_types/util.rb
+++ b/lib/power_types/util.rb
@@ -1,6 +1,6 @@
 module PowerTypes
   module Util
-    OBSERVABLE_EVENTS = [:create, :update, :save, :destroy]
+    OBSERVABLE_EVENTS = [:create, :update, :save, :destroy, :commit]
     OBSERVABLE_TYPES = [:before, :after]
   end
 end

--- a/spec/lib/patterns/observer/observable_spec.rb
+++ b/spec/lib/patterns/observer/observable_spec.rb
@@ -21,6 +21,10 @@ describe PowerTypes::Observable do
       def _run_destroy_callbacks
         "destroy"
       end
+
+      def _run_commit_callbacks
+        "commit"
+      end
     end
 
     class Klass < BaseKlass


### PR DESCRIPTION
Se agrega el evento `commit`, el cual permite el registro de los callbacks `before_commit` y `after_commit` para el observer.