### PR TITLE
Add util pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,37 +245,11 @@ end
 ```
 Note: Triggering the event will preserve the order of the methods, so in the example `kill_villain` will be called before `bury_villains_corpse`.
 
-### Values and Utils
+### Values
 
-These two types don't have generators.
+This pattern doesn't have a generator.
 
 Values are just simple Ruby classes, but watch out to keep them in the Values directory!
-
-Utils should be defined as a module.  There you define the independent but related functions.  Use the extend self pattern to call them directly after the module name.
-
-```ruby
-module MagicTricks
-  extend self
-
-  def dissappear(object)
-    #blah blah
-  end
-
-  def shrink(children)
-    #bleh bleeh
-  end
-
-  def shuffle(cards)
-    #blaah
-  end
-end  
-```
-
-Example of calling a Util function:
-
-```ruby
-MagicTricks.dissapear(rabbit)
-```
 
 ### Presenters
 
@@ -381,6 +355,54 @@ In the view, you can use it like this:
 
 ```
 <div><%= @presenter.platanus_link %></div>
+```
+
+### Utils
+
+To generate a util we use:
+
+```
+$ bundle exec rails g util Numbers clean double
+```
+
+This will generate the `NumbersUtil` class in the `app/utils` directory, as follows:
+
+```ruby
+class NumbersUtil < PowerTypes::BaseUtil
+
+  def self.clean
+    # Method code goes here
+  end
+
+  def self.double
+    # Method code goes here
+  end
+
+end
+```
+
+And it will generate the spec file as well, in the `spec/utils` directory:
+
+```ruby
+require 'rails_helper'
+
+describe NumbersUtil do
+  describe '#clean' do
+    pending 'describe what the util method clean does here'
+  end
+
+  describe '#double' do
+    pending 'describe what the util method double does here'
+  end
+
+end
+```
+
+Every util will inherit from the class `PowerTypes::BaseUtil` which raises an error when the initialize method is called. The purpose of this is to ensure that all the utils methods work as class methods. Thus, there is no need to create an instance of the util to use its methods. For instance, we could use the `NumbersUtil` as follows:
+
+```ruby
+NumbersUtil.clean('5.000') # -> 5000
+NumbersUtil.double(100) # -> 200
 ```
 
 ## Contributing

--- a/lib/generators/rails/templates/util.rb
+++ b/lib/generators/rails/templates/util.rb
@@ -1,0 +1,7 @@
+class <%= class_name %>Util < PowerTypes::BaseUtil
+<% attributes_names.each do |method_name| %>
+  def self.<%= method_name %>
+    # Method code goes here
+  end
+<% end %>
+end

--- a/lib/generators/rails/templates/util_spec.rb
+++ b/lib/generators/rails/templates/util_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+describe <%= class_name %>Util do
+<% attributes_names.each do |method_name| %>
+  describe '#<%= method_name %>' do
+    pending 'describe what the util method <%= method_name %> does here'
+  end
+<% end %>
+end

--- a/lib/generators/rails/util_generator.rb
+++ b/lib/generators/rails/util_generator.rb
@@ -1,0 +1,14 @@
+module Rails
+  class UtilGenerator < Rails::Generators::NamedBase
+    source_root File.expand_path('../templates', __FILE__)
+
+    argument :attributes, type: :array, default: [], banner: 'method method'
+
+    desc 'This generator creates a new util at app/utils'
+
+    def create_util
+      template('util.rb', "app/utils/#{file_name.underscore}_util.rb")
+      template('util_spec.rb', "spec/utils/#{file_name.underscore}_util_spec.rb")
+    end
+  end
+end

--- a/lib/power_types.rb
+++ b/lib/power_types.rb
@@ -10,6 +10,7 @@ require "power_types/patterns/observer/observer"
 require "power_types/patterns/observer/trigger"
 require "power_types/patterns/presenter/base_presenter"
 require "power_types/patterns/presenter/presentable"
+require "power_types/patterns/base_util"
 
 module PowerTypes
 end

--- a/lib/power_types/errors.rb
+++ b/lib/power_types/errors.rb
@@ -1,2 +1,3 @@
 class PowerTypes::Error < RuntimeError; end
 class PowerTypes::PresenterError < PowerTypes::Error; end
+class PowerTypes::UtilError < PowerTypes::Error; end

--- a/lib/power_types/patterns/base_util.rb
+++ b/lib/power_types/patterns/base_util.rb
@@ -1,0 +1,7 @@
+module PowerTypes
+  class BaseUtil
+    def initialize
+      raise PowerTypes::UtilError.new('a util cannot be instantiated')
+    end
+  end
+end

--- a/spec/lib/patterns/base_util_spec.rb
+++ b/spec/lib/patterns/base_util_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+describe PowerTypes::BaseUtil do
+  context 'when it is initialized' do
+    let(:error) { 'a util cannot be instantiated' }
+
+    it { expect { described_class.new }.to raise_error(PowerTypes::UtilError, error) }
+  end
+end


### PR DESCRIPTION
### Utils

To generate a util we use:

```
$ bundle exec rails g util Numbers clean double
```

This will generate the `NumbersUtil` class in the `app/utils` directory, as follows:

```ruby
class NumbersUtil < PowerTypes::BaseUtil

  def self.clean
    # Method code goes here
  end

  def self.double
    # Method code goes here
  end

end
```

And it will generate the spec file as well, in the `spec/utils` directory:

```ruby
require 'rails_helper'

describe NumbersUtil do
  describe '#clean' do
    pending 'describe what the util method clean does here'
  end

  describe '#double' do
    pending 'describe what the util method double does here'
  end

end
```

Every util will inherit from the class `PowerTypes::BaseUtil` which raises an error when the initialize method is called. The purpose of this is to ensure that all the utils methods work as class methods. Thus, there is no need to create an instance of the util to use its methods. For instance, we could use the `NumbersUtil` as follows:

```ruby
NumbersUtil.clean('5.000') # -> 5000
NumbersUtil.double(100) # -> 200
```
