### PR TITLE
Fix commit callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,8 @@ end
 ```
 Note: Triggering the event will preserve the order of the methods, so in the example `kill_villain` will be called before `bury_villains_corpse`.
 
+Recently we added three new callbacks, `after_create_commit`, `after_update_commit` and `after_save_commit`. With these callbacks we want to reproduce the `after_commit` transactional callback from Active Record. For this implementation we use the gem [After Commit Everywhere](https://github.com/Envek/after_commit_everywhere) to be able to use the `after_commit` callbacks outside the Active Record models.
+
 ### Values
 
 This pattern doesn't have a generator.

--- a/lib/power_types.rb
+++ b/lib/power_types.rb
@@ -1,16 +1,17 @@
-require "active_support/all"
+require 'active_support/all'
+require 'after_commit_everywhere'
 
-require "power_types/version"
-require "power_types/util"
-require "power_types/errors"
-require "power_types/patterns/service"
-require "power_types/patterns/command"
-require "power_types/patterns/observer/observable"
-require "power_types/patterns/observer/observer"
-require "power_types/patterns/observer/trigger"
-require "power_types/patterns/presenter/base_presenter"
-require "power_types/patterns/presenter/presentable"
-require "power_types/patterns/base_util"
+require 'power_types/version'
+require 'power_types/util'
+require 'power_types/errors'
+require 'power_types/patterns/service'
+require 'power_types/patterns/command'
+require 'power_types/patterns/observer/observable'
+require 'power_types/patterns/observer/observer'
+require 'power_types/patterns/observer/trigger'
+require 'power_types/patterns/presenter/base_presenter'
+require 'power_types/patterns/presenter/presentable'
+require 'power_types/patterns/base_util'
 
 module PowerTypes
 end

--- a/lib/power_types/util.rb
+++ b/lib/power_types/util.rb
@@ -1,6 +1,7 @@
 module PowerTypes
   module Util
-    OBSERVABLE_EVENTS = [:create, :update, :save, :destroy, :commit]
+    OBSERVABLE_EVENTS = [:create, :update, :save, :destroy]
+    OBSERVABLE_TRANSACTIONAL_EVENTS = [:create_commit, :update_commit, :save_commit]
     OBSERVABLE_TYPES = [:before, :after]
   end
 end

--- a/power-types.gemspec
+++ b/power-types.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "activesupport"
+  spec.add_dependency "after_commit_everywhere", "~> 1.2", ">= 1.2.2"
 
   spec.add_development_dependency "bundler", "~> 2.2.15"
   spec.add_development_dependency "coveralls"

--- a/spec/lib/patterns/observer/observer_spec.rb
+++ b/spec/lib/patterns/observer/observer_spec.rb
@@ -17,17 +17,70 @@ describe PowerTypes::Observer do
 
   it { expect(described_class.triggers.count).to eq(3) }
 
-  it "calls valid trigger" do
+  it 'calls valid trigger' do
     expect(@t1).to receive(:call).with(instance_of(PowerTypes::Observer)).and_return(true)
     expect(described_class).to receive(:new).with(observable).and_call_original
     described_class.trigger(:before, :save, observable)
   end
 
-  it "calls valid trigger" do
+  it 'calls valid trigger' do
     expect(@t2).to receive(:call).with(instance_of(PowerTypes::Observer)).and_return(true)
     expect(@t3).to receive(:call).with(instance_of(PowerTypes::Observer)).and_return(true)
     expect(described_class).to receive(:new).with(observable).twice.and_call_original
 
     described_class.trigger(:after, :create, observable)
+  end
+
+  describe '#after commit callbacks' do
+    let(:observer) { described_class.new(observable) }
+    let(:method) { :method }
+
+    describe '#execute_method_after_commit' do
+      let(:send) { observer.send(method) }
+      let(:after_commit) { -> { send } }
+
+      before do
+        allow(observer).to receive(:after_commit).and_invoke(after_commit)
+        allow(observer).to receive(:send).with(method)
+        observer.execute_method_after_commit(method)
+      end
+
+      it { expect(observer).to have_received(:after_commit) }
+      it { expect(observer).to have_received(:send).with(method) }
+    end
+
+    shared_examples 'after_commit_callback' do
+      let(:after_callback) { -> { described_class.execute_method_after_commit(method) } }
+
+      before do
+        allow(described_class).to receive(callback).and_invoke(after_callback)
+        allow(described_class).to receive(:execute_method_after_commit).with(method)
+        execute_callback
+      end
+
+      it { expect(described_class).to have_received(callback) }
+      it { expect(described_class).to have_received(:execute_method_after_commit).with(method) }
+    end
+
+    describe '#after_create_commit' do
+      let(:execute_callback) { described_class.after_create_commit(method) }
+      let(:callback) { :after_create }
+
+      it_behaves_like 'after_commit_callback'
+    end
+
+    describe '#after_update_commit' do
+      let(:execute_callback) { described_class.after_update_commit(method) }
+      let(:callback) { :after_update }
+
+      it_behaves_like 'after_commit_callback'
+    end
+
+    describe '#after_save_commit' do
+      let(:execute_callback) { described_class.after_save_commit(method) }
+      let(:callback) { :after_save }
+
+      it_behaves_like 'after_commit_callback'
+    end
   end
 end


### PR DESCRIPTION
**Contexto**

En un PR anterior se agregó el callback `after_commit`. Este no estaba funcionando debido a que es un callback transaccional, los que tienen un flujo dentro del código diferente a los callbacks del life cycle de un objeto de ActiveRecord.

**Qué se está haciendo**

Para poder arreglar lo explicado anteriormente hay dos opciones:

- La primera implica hacerlo de manera similar a los callbacks actuales, haciendo override a algunos métodos de clase de Rails que se encargan de ejecutar los callbacks. Esta opción fue dejada de lado ya que el flujo de los callbacks transaccionales es más complejo, no siempre está activado y depende de una conexión a la db (la transacción), por lo que los cambios del override pueden inducir a comportamientos más complejos de resolver o errores que no sabemos que podrían ocurrir.

- La segunda implica utilizar una dependencia, [after_commit_everywhere](https://github.com/Envek/after_commit_everywhere), que es una gema especializada en poder usar los callbacks transaccionales fuera de un modelo de ActiveRecord. Esta fue la opción elegida ya que la implementación es más simple y la complejidad de la transacción la maneja la gema.

Entonces, los cambios fueron:

- Se agrega la gema `after_commit_everywhere` como dependencia.
- Se agregan los callbacks transaccionales a la `PowerTypes::Util`.
- Se agregan los métodos de clase `after_create_commit`, `after_update_commit` y `after_save_commit` al `PowerTypes::Observer`. Además, se agrega el método de instancia `execute_method_after_commit` al `PowerTypes::Observer`, que es el método que es ejecutado por cada uno de los tres anteriores y que se encarga de hacer el `send` después de que el objeto fue commiteado en la db.