### PR TITLE
After destroy commit callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ end
 ```
 Note: Triggering the event will preserve the order of the methods, so in the example `kill_villain` will be called before `bury_villains_corpse`.
 
-Recently we added three new callbacks, `after_create_commit`, `after_update_commit` and `after_save_commit`. With these callbacks we want to reproduce the `after_commit` transactional callback from Active Record. For this implementation we use the gem [After Commit Everywhere](https://github.com/Envek/after_commit_everywhere) to be able to use the `after_commit` callbacks outside the Active Record models.
+Recently we added four new callbacks, `after_create_commit`, `after_update_commit`, `after_save_commit` and `after_destroy_commit`. With these callbacks we want to reproduce the `after_commit` transactional callback from Active Record. For this implementation we use the gem [After Commit Everywhere](https://github.com/Envek/after_commit_everywhere) to be able to use the `after_commit` callbacks outside the Active Record models.
 
 ### Values
 

--- a/lib/power_types/util.rb
+++ b/lib/power_types/util.rb
@@ -1,7 +1,8 @@
 module PowerTypes
   module Util
     OBSERVABLE_EVENTS = [:create, :update, :save, :destroy]
-    OBSERVABLE_TRANSACTIONAL_EVENTS = [:create_commit, :update_commit, :save_commit]
+    OBSERVABLE_TRANSACTIONAL_EVENTS = [:create_commit, :update_commit, :save_commit,
+                                       :destroy_commit]
     OBSERVABLE_TYPES = [:before, :after]
   end
 end

--- a/spec/lib/patterns/observer/observer_spec.rb
+++ b/spec/lib/patterns/observer/observer_spec.rb
@@ -82,5 +82,12 @@ describe PowerTypes::Observer do
 
       it_behaves_like 'after_commit_callback'
     end
+
+    describe '#after_destroy_commit' do
+      let(:execute_callback) { described_class.after_destroy_commit(method) }
+      let(:callback) { :after_destroy }
+
+      it_behaves_like 'after_commit_callback'
+    end
   end
 end


### PR DESCRIPTION
Este PR agrega el callback `after_destroy_commit` basado en [este pr](https://github.com/platanus/power-types/pull/24)