### PR TITLE
Fix/presenter param decoration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## Unreleased
+
+Features
+  - Add after_destroy_commit callback [#25](https://github.com/platanus/power-types/pull/25)
+
+Fixes
+  - Fix presenter params decoration [#26](https://github.com/platanus/power-types/pull/26)

--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ To initialize a presenter inside your controller action you should execute the `
 class UsersController < InheritedResources::Base
   def show
     presenter_params = { param1: 1, param2: 2 }
-    @presenter = present_with(:users_show, presenter_params)
+    @presenter = present_with(:users_show_presenter, presenter_params)
   end
 end
 ```
@@ -317,7 +317,7 @@ You can access `presenter_params` inside the presenter as an `attr_reader`
 class UsersController < InheritedResources::Base
   def show
     presenter_params = { platanus_url: "https://platan.us" }
-    @presenter = present_with(:users_show, presenter_params)
+    @presenter = present_with(:users_show_presenter, presenter_params)
   end
 end
 ```
@@ -336,7 +336,7 @@ If the presenter param has a [decorator](https://github.com/drapergem/draper), t
 class UsersController < InheritedResources::Base
   def show
     presenter_params = { user: user }
-    @presenter = present_with(:users_show, presenter_params)
+    @presenter = present_with(:users_show_presenter, presenter_params)
   end
 
   private

--- a/lib/power_types/patterns/presenter/base_presenter.rb
+++ b/lib/power_types/patterns/presenter/base_presenter.rb
@@ -20,9 +20,9 @@ module PowerTypes
     attr_reader :h
 
     def decorated_value(value)
-      return value unless value.respond_to?(:decorate)
-
       value.decorate
+    rescue NameError
+      value
     end
   end
 end

--- a/spec/lib/presenter/base_presenter_spec.rb
+++ b/spec/lib/presenter/base_presenter_spec.rb
@@ -4,11 +4,11 @@ require 'spec_helper'
 describe PowerTypes::BasePresenter do
   let(:view) { double(view_method: 2) }
   let(:decorated_object) { double }
-  let(:decorable_instance) { double(decorate: decorated_object) }
+  let(:instance_to_decorate) { double(decorate: decorated_object) }
   let(:params) do
     {
       simple_param: 1,
-      decorated_param: decorable_instance
+      decorated_param: instance_to_decorate
     }
   end
 
@@ -20,6 +20,16 @@ describe PowerTypes::BasePresenter do
   it { expect(presenter.simple_param).to eq(1) }
   it { expect(presenter.decorated_param).to eq(decorated_object) }
   it { expect(presenter.send(:h).view_method).to eq(2) }
+
+  context "when the instance can't be decorated" do
+    let(:instance_to_decorate) { double }
+
+    before do
+      allow(instance_to_decorate).to receive(:decorate).and_raise(NameError)
+    end
+
+    it { expect(presenter.decorated_param).to eq(instance_to_decorate) }
+  end
 
   context "with already defined presenter method" do
     let(:error) { "attribute simple_param already defined in presenter" }


### PR DESCRIPTION
### Context
The presenter type has a bug where presenter parameters that did not have a [decorator](https://github.com/drapergem/draper) were decorated, resulting in a `Draper::UninferrableDecoratorError`.

Additionally, the readme examples for a presenter were incorrect, as the first argument in the `present_with` calls should match with the desired presenter class name. For instance, if the presenter is called `UsersShowPresenter`, the argument must be `:users_show_presenter`

### What is being done
1.. Error handling has been added to the `BasePresenter`'s `decorated_value` method. To avoid adding Draper as a dependency, `NameError` is rescued.
2. All `present_with` calls now include the `_presenter` suffix in the first argument to ensure that the correct presenter is used.
